### PR TITLE
symbol is not esc in code_spmd

### DIFF
--- a/src/pass.jl
+++ b/src/pass.jl
@@ -362,5 +362,5 @@ using InteractiveUtils: typesof
 
 macro code_spmd(ex)
   @capture(ex, f_(xs__)) || error("@code_spmd f(xs...)")
-  :(IRTools.code_ir($(esc(f)), typesof($(xs...))) |> pass)
+  :(IRTools.code_ir($(esc(f)), typesof($(esc(xs...)))) |> pass)
 end


### PR DESCRIPTION
MWE:

```jl
vA = VecArray{Float64, Array{Float64, 3}, 10}(rand(2, 2, 10), ntuple(_->(2, 2), 10))

julia> Hydra.@code_spmd tr(vA)
ERROR: UndefVarError: vA not defined
Stacktrace:
 [1] top-level scope at none:0

julia> @macroexpand Hydra.@code_spmd tr(vA)
:((Hydra.IRTools).code_ir(tr, (Hydra.typesof)(Hydra.vA)) |> Hydra.pass)
```